### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/jetbrains
+* @tinted-theming/jetbrains

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Create a report to help us improve
 title: "[Bug report] "
 labels: ["bug"]
 assignees: 
-  - base16-project/jetbrains
+  - tinted-theming/jetbrains
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest an idea for this project
 title: "[Feature request] "
 labels: ["feature"]
 assignees: 
-  - base16-project/jetbrains
+  - tinted-theming/jetbrains
 ---
 
 ## Is your feature request related to a problem? Please describe.

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update with the latest base16 colorschemes
+name: Update with the latest colorschemes
 on:
   workflow_dispatch:
   schedule:
@@ -13,12 +13,12 @@ jobs:
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Update with the latest base16-project colorschemes
+          commit_message: Update with the latest tinted-theming colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Or the above steps represented in shell commands:
 
 ```shell 
 cd /path/to/base16-jetbrains/../ # This repos parent dir 
-git clone git@github.com:base16-project/base16-builder-go.git
+git clone git@github.com:tinted-theming/base16-builder-go.git
 cd base16-builder-go
 go build ./base16-builder-go/base16-builder-go \
   -template-dir ../base16-jetbrains
@@ -59,8 +59,8 @@ Please follow the instructions in the issue templates:
 - [Issue template for bug reports][5]
 - [Issue template for feature requests][6]
 
-[1]: https://github.com/base16-project/base16-builder-go
-[2]: https://github.com/base16-project/base16-schemes
+[1]: https://github.com/tinted-theming/base16-builder-go
+[2]: https://github.com/tinted-theming/base16-schemes
 [3]: .github/workflows/update.yml
 [4]: .github/pull_request_template.md
 [5]: .github/ISSUE_TEMPLATE/bug_report.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Andrew DiLosa
-Copyright (c) 2022 [Tinted Theming](https://github.com/tinted-theming)
+Copyright (c) 2022 Tinted Theming (https://github.com/tinted-theming)
 
 Template XML based on Material Theme Jetbrains:
 Copyright (c) 2017 Chris Magnussen and Elior Boukhobza

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Andrew DiLosa
+Copyright (c) 2022 [Tinted Theming](https://github.com/tinted-theming)
 
 Template XML based on Material Theme Jetbrains:
 Copyright (c) 2017 Chris Magnussen and Elior Boukhobza

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It is also possible to download a scheme into the IDE's config directory
 
 ```shell
 curl \
-  https://raw.githubusercontent.com/base16-project/base16-jetbrains/main/colors/base16-eighties.icls \
+  https://raw.githubusercontent.com/tinted-theming/base16-jetbrains/main/colors/base16-eighties.icls \
   > ~/.PyCharm2018.1/config/colors/base16-eighties.icls
 ```
 
@@ -43,11 +43,11 @@ See [`CONTRIBUTING.md`][9], which contains building and contributing
 instructions.
 
 [1]: https://github.com/ChrisRM/material-theme-jetbrains
-[2]: https://github.com/base16-project/home
+[2]: https://github.com/tinted-theming/home
 [3]: colors.jar?raw=true
 [4]: colors
 [5]: options
-[6]: https://github.com/base16-project/home#builder-repositories
+[6]: https://github.com/tinted-theming/home#builder-repositories
 [7]: .github/workflows/update.yml
 [8]: https://github.com/obahareth/base16-builder-ruby
 [9]: CONTRIBUTING.md

--- a/templates/accent.mustache
+++ b/templates/accent.mustache
@@ -1,5 +1,6 @@
 <!--    Base16 {{scheme-name}}
-        Author: {{scheme-author}}   -->
+        Scheme author: {{scheme-author}}
+	Template author: Tinted Theming (https://github.com/tinted-theming)   -->
 
 <application>
   <component name="MaterialThemeConfig">

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,5 +1,6 @@
 <!--    Base16 {{scheme-name}}
-        Author: {{scheme-author}}   -->
+        Scheme author: {{scheme-author}}
+	Template author: Tinted Theming (https://github.com/tinted-theming)   -->
 
 <scheme name="Base16 {{scheme-name}}" version="142" parent_scheme="Darcula">
     <colors>

--- a/templates/scheme.mustache
+++ b/templates/scheme.mustache
@@ -1,5 +1,6 @@
 <!--    Base16 {{scheme-name}}
-        Author: {{scheme-author}}   -->
+        Scheme author: {{scheme-author}}
+	Template author: Tinted Theming (https://github.com/tinted-theming)   -->
 
 <application>
   <component name="EditorColorsManagerImpl">

--- a/templates/theme.mustache
+++ b/templates/theme.mustache
@@ -1,5 +1,6 @@
 <!--    Base16 {{scheme-name}}
-        Author: {{scheme-author}}   -->
+        Scheme author: {{scheme-author}}
+	Template author: Tinted Theming (https://github.com/tinted-theming)   -->
 
 <application>
   <component name="MaterialCustomThemeConfig">


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.